### PR TITLE
feat: add search clients, average click position, session details API…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "su-sdk",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "description": "SearchUnify javascript SDK enables developers to easily work with the SearchUnify platform and build scalable solutions with search, analytics, crawlers and more.",
     "main": "index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     ],
     "scripts": {
         "lint": "eslint './src/**/*.js'",
-        "lint-fix": "eslint --fix './src/**/*.js'"
+        "lint-fix": "eslint --fix './src/**/*.js'",
+        "test": "node --test 'test/**/*.js'"
     },
     "author": "SearchUnify",
     "license": "MIT",

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -65,14 +65,13 @@ class Analytics extends Base {
   }
 
   getAllSearchQuery(params) {
-    validate(analytics.similarValidationWithCountAndOffset, params);
+    validate(analytics.similarValidationWithCount, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
-      offset: params.offset,
     });
 
     return HttpRequest({
@@ -83,14 +82,13 @@ class Analytics extends Base {
   }
 
   searchQueryWithResult(params) {
-    validate(analytics.similarValidationWithCountAndOffset, params);
+    validate(analytics.similarValidationWithCount, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
-      offset: params.offset,
     });
 
     return HttpRequest({
@@ -101,14 +99,13 @@ class Analytics extends Base {
   }
 
   searchQueryWithNoClicks(params) {
-    validate(analytics.similarValidationWithCountAndOffset, params);
+    validate(analytics.similarValidationWithCount, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
-      offset: params.offset,
     });
 
     return HttpRequest({
@@ -119,14 +116,13 @@ class Analytics extends Base {
   }
 
   searchQueryWithoutResults(params) {
-    validate(analytics.similarValidationWithCountAndOffset, params);
+    validate(analytics.similarValidationWithCount, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
-      offset: params.offset,
     });
 
     return HttpRequest({
@@ -203,14 +199,13 @@ class Analytics extends Base {
   }
 
   getAllSearchConversion(params) {
-    validate(analytics.similarValidationWithCountAndOffset, params);
+    validate(analytics.similarValidationWithCount, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
-      offset: params.offset,
     });
 
     return HttpRequest({
@@ -478,7 +473,6 @@ class Analytics extends Base {
       startDate: params.startDate,
       endDate: params.endDate,
       searchClientId: params.searchClientId,
-      offset: params.offset,
       count: params.count,
     });
 
@@ -498,7 +492,6 @@ class Analytics extends Base {
       endDate: params.endDate,
       uid: params.searchClientId,
       count: params.count,
-      startIndex: params.startIndex,
     });
 
     return HttpRequest({

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -65,13 +65,14 @@ class Analytics extends Base {
   }
 
   getAllSearchQuery(params) {
-    validate(analytics.similarValidationWithCount, params);
+    validate(analytics.similarValidationWithCountAndOffset, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
+      offset: params.offset,
     });
 
     return HttpRequest({
@@ -82,13 +83,14 @@ class Analytics extends Base {
   }
 
   searchQueryWithResult(params) {
-    validate(analytics.similarValidationWithCount, params);
+    validate(analytics.similarValidationWithCountAndOffset, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
+      offset: params.offset,
     });
 
     return HttpRequest({
@@ -99,13 +101,14 @@ class Analytics extends Base {
   }
 
   searchQueryWithNoClicks(params) {
-    validate(analytics.similarValidationWithCount, params);
+    validate(analytics.similarValidationWithCountAndOffset, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
+      offset: params.offset,
     });
 
     return HttpRequest({
@@ -116,13 +119,14 @@ class Analytics extends Base {
   }
 
   searchQueryWithoutResults(params) {
-    validate(analytics.similarValidationWithCount, params);
+    validate(analytics.similarValidationWithCountAndOffset, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
+      offset: params.offset,
     });
 
     return HttpRequest({
@@ -199,13 +203,14 @@ class Analytics extends Base {
   }
 
   getAllSearchConversion(params) {
-    validate(analytics.similarValidationWithCount, params);
+    validate(analytics.similarValidationWithCountAndOffset, params);
 
     const queryParams = qs.stringify({
       startDate: params.startDate,
       endDate: params.endDate,
       count: params.count,
       searchClientId: params.searchClientId,
+      offset: params.offset,
     });
 
     return HttpRequest({
@@ -463,6 +468,43 @@ class Analytics extends Base {
       timeout: this.#timeout,
       method: requestMethods.get,
       url: `${this.#instance}${ANALYTICS.SEARCH_SESSION_BY_SESSION_ID}/${params.sessionId}?${queryParams}`
+    }, this.#authObj);
+  }
+
+  getAverageClickPosition(params) {
+    validate(analytics.averageClickPositionValidation, params);
+
+    const payload = JSON.stringify({
+      startDate: params.startDate,
+      endDate: params.endDate,
+      searchClientId: params.searchClientId,
+      offset: params.offset,
+      count: params.count,
+    });
+
+    return HttpRequest({
+      timeout: this.#timeout,
+      method: requestMethods.post,
+      url: `${this.#instance}${ANALYTICS.AVERAGE_CLICK_POSITION}`,
+      data: payload
+    }, this.#authObj);
+  }
+
+  getSessionDetails(params) {
+    validate(analytics.sessionDetailsValidation, params);
+
+    const queryParams = qs.stringify({
+      startDate: params.startDate,
+      endDate: params.endDate,
+      uid: params.searchClientId,
+      count: params.count,
+      startIndex: params.startIndex,
+    });
+
+    return HttpRequest({
+      timeout: this.#timeout,
+      method: requestMethods.get,
+      url: `${this.#instance}${ANALYTICS.SESSION_LOG}?${queryParams}`
     }, this.#authObj);
   }
 }

--- a/src/core/search-clients.js
+++ b/src/core/search-clients.js
@@ -1,0 +1,28 @@
+const { CONTENT_API } = require('../utils/su-apis');
+const { HttpRequest, requestMethods } = require('../utils/request-handler');
+const { Base } = require('./base');
+
+class SearchClients extends Base {
+  #instance;
+
+  #timeout;
+
+  #authObj;
+
+  constructor(props, authObj) {
+    super(props);
+    this.#instance = props.instance;
+    this.#timeout = props.timeout;
+    this.#authObj = authObj;
+  }
+
+  getSearchClients = async () => HttpRequest({
+    timeout: this.#timeout,
+    method: requestMethods.get,
+    url: `${this.#instance}${CONTENT_API.SEARCH_CLIENTS}`
+  }, this.#authObj);
+}
+
+module.exports = {
+  SearchClients
+};

--- a/src/core/su-rest-client.js
+++ b/src/core/su-rest-client.js
@@ -5,6 +5,7 @@ const { DEFAULT_TIMEOUT } = require('../utils/constants');
 const { Analytics } = require('./analytics');
 const { Content } = require('./content');
 const { Search } = require('./search');
+const { SearchClients } = require('./search-clients');
 
 /**
  * @class Searchunify Rest Client
@@ -23,6 +24,8 @@ class SearchUnifyRestClient {
 
   #search;
 
+  #searchClients;
+
   constructor(props) {
     joiValidator.validate(validations.client.initialize, props);
 
@@ -33,6 +36,7 @@ class SearchUnifyRestClient {
     this.#analytics = new Analytics(props, this.#authentication);
     this.#content = new Content(props, this.#authentication);
     this.#search = new Search(props, this.#authentication);
+    this.#searchClients = new SearchClients(props, this.#authentication);
   }
 
   Analytics() {
@@ -45,6 +49,10 @@ class SearchUnifyRestClient {
 
   Search() {
     return this.#search;
+  }
+
+  SearchClients() {
+    return this.#searchClients;
   }
 }
 

--- a/src/utils/su-apis.js
+++ b/src/utils/su-apis.js
@@ -20,7 +20,9 @@ exports.ANALYTICS = {
   ARTICLE_CREATED_CASES: '/api/v2/conversion/articlesCreatedCases',
   ARTICLE_DEFLECTED_CASES: '/api/v2/conversion/articlesDeflectedCase',
   ATTACHED_ARTICLE: '/api/v2/conversion/attachedArticles',
-  ATTACHED_ON_CASE: '/api/v2/conversion/attachedOnCase'
+  ATTACHED_ON_CASE: '/api/v2/conversion/attachedOnCase',
+  AVERAGE_CLICK_POSITION: '/api/v2/searchQuery/averageClickPosition',
+  SESSION_LOG: '/api/v2/session/log/all'
 };
 
 exports.AUTH_API = {
@@ -39,5 +41,6 @@ exports.CONTENT_API = {
   OBJECT_DATA: '/api/v2_cs/apiData/contentSource/<contentSourceId>/object/<objectId>/get',
   OBJECT_DATA_WITH_ID: '/api/v2_cs/apiData/contentSource/<contentSourceId>/object/<objectId>/document/<documentId>/get',
   UPDATE_DOC_BY_ID: '/api/v2_cs/apiData/contentSource/<contentSourceId>/object/<objectId>/document/<documentId>/update',
-  BATCH_UPLOAD: '/api/v2_cs/apiData/contentSource/<contentSourceId>/object/<objectId>/bulkUpload'
+  BATCH_UPLOAD: '/api/v2_cs/apiData/contentSource/<contentSourceId>/object/<objectId>/bulkUpload',
+  SEARCH_CLIENTS: '/api/v1/search-clients'
 };

--- a/src/utils/su-apis.js
+++ b/src/utils/su-apis.js
@@ -42,5 +42,5 @@ exports.CONTENT_API = {
   OBJECT_DATA_WITH_ID: '/api/v2_cs/apiData/contentSource/<contentSourceId>/object/<objectId>/document/<documentId>/get',
   UPDATE_DOC_BY_ID: '/api/v2_cs/apiData/contentSource/<contentSourceId>/object/<objectId>/document/<documentId>/update',
   BATCH_UPLOAD: '/api/v2_cs/apiData/contentSource/<contentSourceId>/object/<objectId>/bulkUpload',
-  SEARCH_CLIENTS: '/api/v1/search-clients'
+  SEARCH_CLIENTS: '/api/v2/search-clients'
 };

--- a/src/validations/analytics-validation.js
+++ b/src/validations/analytics-validation.js
@@ -116,7 +116,6 @@ const averageClickPositionValidation = Joi.object().keys({
   startDate: Joi.string().trim().required(),
   endDate: Joi.string().trim().required(),
   searchClientId: Joi.string().uuid().trim().optional(),
-  offset: Joi.number().min(1).optional(),
   count: Joi.number().min(1).max(500).optional(),
 });
 
@@ -125,20 +124,6 @@ const sessionDetailsValidation = Joi.object().keys({
   endDate: Joi.string().trim().required(),
   searchClientId: Joi.string().uuid().trim().required(),
   count: Joi.number().min(1).max(500).optional(),
-  startIndex: Joi.number().min(1).optional(),
-});
-
-const similarValidationWithCountAndOffset = Joi.object().keys({
-  startDate: Joi.string().trim().required(),
-  endDate: Joi.string().trim().required(),
-  count: Joi.number().min(1).max(500).required(),
-  searchClientId: Joi.string().uuid().trim(),
-  ecoSystemId: Joi.string().trim().optional(),
-  offset: Joi.number().min(1).optional(),
-  ...userMetricsValidation,
-  pageNumber: Joi.number().optional(),
-}).nand('searchClientId', 'ecoSystemId').messages({
-  'object.nand': 'searchClientId and ecoSystemId cannot be used together',
 });
 
 const searchSessionBySSIdValidation = Joi.object().keys({
@@ -153,7 +138,6 @@ const searchSessionBySSIdValidation = Joi.object().keys({
 module.exports = {
   similarValidation,
   similarValidationWithCount,
-  similarValidationWithCountAndOffset,
   searchSessionByCaseUidValidation,
   searchConversionWithFilters,
   searchConversionBySessionId,

--- a/src/validations/analytics-validation.js
+++ b/src/validations/analytics-validation.js
@@ -112,6 +112,35 @@ const attachedOnCaseValidation = Joi.object().keys({
   'object.nand': 'searchClientId and ecoSystemId cannot be used together',
 });
 
+const averageClickPositionValidation = Joi.object().keys({
+  startDate: Joi.string().trim().required(),
+  endDate: Joi.string().trim().required(),
+  searchClientId: Joi.string().uuid().trim().optional(),
+  offset: Joi.number().min(1).optional(),
+  count: Joi.number().min(1).max(500).optional(),
+});
+
+const sessionDetailsValidation = Joi.object().keys({
+  startDate: Joi.string().trim().required(),
+  endDate: Joi.string().trim().required(),
+  searchClientId: Joi.string().uuid().trim().required(),
+  count: Joi.number().min(1).max(500).optional(),
+  startIndex: Joi.number().min(1).optional(),
+});
+
+const similarValidationWithCountAndOffset = Joi.object().keys({
+  startDate: Joi.string().trim().required(),
+  endDate: Joi.string().trim().required(),
+  count: Joi.number().min(1).max(500).required(),
+  searchClientId: Joi.string().uuid().trim(),
+  ecoSystemId: Joi.string().trim().optional(),
+  offset: Joi.number().min(1).optional(),
+  ...userMetricsValidation,
+  pageNumber: Joi.number().optional(),
+}).nand('searchClientId', 'ecoSystemId').messages({
+  'object.nand': 'searchClientId and ecoSystemId cannot be used together',
+});
+
 const searchSessionBySSIdValidation = Joi.object().keys({
   startDate: Joi.string().trim().required(),
   endDate: Joi.string().trim().required(),
@@ -124,6 +153,7 @@ const searchSessionBySSIdValidation = Joi.object().keys({
 module.exports = {
   similarValidation,
   similarValidationWithCount,
+  similarValidationWithCountAndOffset,
   searchSessionByCaseUidValidation,
   searchConversionWithFilters,
   searchConversionBySessionId,
@@ -131,5 +161,7 @@ module.exports = {
   caseArticlesValidation,
   attachedArticlesValidation,
   attachedOnCaseValidation,
-  searchSessionBySSIdValidation
+  searchSessionBySSIdValidation,
+  averageClickPositionValidation,
+  sessionDetailsValidation
 };

--- a/test/test-new-apis.js
+++ b/test/test-new-apis.js
@@ -41,7 +41,6 @@ describe('averageClickPositionValidation', () => {
       startDate: '2025-01-01',
       endDate: '2025-01-31',
       searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-      offset: 1,
       count: 50,
     });
     assert.ok(result);
@@ -74,13 +73,12 @@ describe('sessionDetailsValidation', () => {
     assert.ok(result);
   });
 
-  it('should pass with optional startIndex and count', () => {
+  it('should pass with optional count', () => {
     const result = validate(analyticsValidation.sessionDetailsValidation, {
       startDate: '2025-01-01',
       endDate: '2025-01-31',
       searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       count: 10,
-      startIndex: 2,
     });
     assert.ok(result);
   });
@@ -95,39 +93,6 @@ describe('sessionDetailsValidation', () => {
   });
 });
 
-describe('similarValidationWithCountAndOffset', () => {
-  it('should pass with offset', () => {
-    const result = validate(analyticsValidation.similarValidationWithCountAndOffset, {
-      startDate: '2025-01-01',
-      endDate: '2025-01-31',
-      count: 10,
-      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-      offset: 2,
-    });
-    assert.ok(result);
-  });
-
-  it('should pass without offset (backward compatible)', () => {
-    const result = validate(analyticsValidation.similarValidationWithCountAndOffset, {
-      startDate: '2025-01-01',
-      endDate: '2025-01-31',
-      count: 10,
-      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-    });
-    assert.ok(result);
-  });
-
-  it('should fail with count over 500', () => {
-    assert.throws(() => {
-      validate(analyticsValidation.similarValidationWithCountAndOffset, {
-        startDate: '2025-01-01',
-        endDate: '2025-01-31',
-        count: 501,
-        searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-      });
-    });
-  });
-});
 
 // --- Class instantiation ---
 
@@ -181,24 +146,15 @@ describe('Content class - getSearchClients removed', () => {
   });
 });
 
-// --- Pagination backward compatibility ---
+// --- Existing methods unchanged ---
 
-describe('Existing methods accept offset param', () => {
-  it('getAllSearchQuery validates with offset', () => {
-    const result = validate(analyticsValidation.similarValidationWithCountAndOffset, {
+describe('Existing methods use similarValidationWithCount', () => {
+  it('validates with count (no offset)', () => {
+    const result = validate(analyticsValidation.similarValidationWithCount, {
       startDate: '2025-01-01',
       endDate: '2025-01-31',
       count: 10,
-      offset: 3,
-    });
-    assert.ok(result);
-  });
-
-  it('getAllSearchQuery validates without offset (backward compat)', () => {
-    const result = validate(analyticsValidation.similarValidationWithCountAndOffset, {
-      startDate: '2025-01-01',
-      endDate: '2025-01-31',
-      count: 10,
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
     });
     assert.ok(result);
   });

--- a/test/test-new-apis.js
+++ b/test/test-new-apis.js
@@ -21,7 +21,7 @@ describe('su-apis URLs', () => {
   });
 
   it('should have SEARCH_CLIENTS url', () => {
-    assert.equal(CONTENT_API.SEARCH_CLIENTS, '/api/v1/search-clients');
+    assert.equal(CONTENT_API.SEARCH_CLIENTS, '/api/v2/search-clients');
   });
 });
 

--- a/test/test-new-apis.js
+++ b/test/test-new-apis.js
@@ -1,0 +1,205 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { Analytics } = require('../src/core/analytics');
+const { Content } = require('../src/core/content');
+const { SearchClients } = require('../src/core/search-clients');
+const { SearchUnifyRestClient } = require('../src/core/su-rest-client');
+const analyticsValidation = require('../src/validations/analytics-validation');
+const { ANALYTICS, CONTENT_API } = require('../src/utils/su-apis');
+const { validate } = require('../src/validations/joi-validator');
+
+// --- API URL constants ---
+
+describe('su-apis URLs', () => {
+  it('should have AVERAGE_CLICK_POSITION url', () => {
+    assert.equal(ANALYTICS.AVERAGE_CLICK_POSITION, '/api/v2/searchQuery/averageClickPosition');
+  });
+
+  it('should have SESSION_LOG url', () => {
+    assert.equal(ANALYTICS.SESSION_LOG, '/api/v2/session/log/all');
+  });
+
+  it('should have SEARCH_CLIENTS url', () => {
+    assert.equal(CONTENT_API.SEARCH_CLIENTS, '/api/v1/search-clients');
+  });
+});
+
+// --- Validation schemas ---
+
+describe('averageClickPositionValidation', () => {
+  it('should pass with valid required params', () => {
+    const result = validate(analyticsValidation.averageClickPositionValidation, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+    });
+    assert.ok(result);
+  });
+
+  it('should pass with all optional params', () => {
+    const result = validate(analyticsValidation.averageClickPositionValidation, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      offset: 1,
+      count: 50,
+    });
+    assert.ok(result);
+  });
+
+  it('should fail without startDate', () => {
+    assert.throws(() => {
+      validate(analyticsValidation.averageClickPositionValidation, {
+        endDate: '2025-01-31',
+      });
+    });
+  });
+
+  it('should fail without endDate', () => {
+    assert.throws(() => {
+      validate(analyticsValidation.averageClickPositionValidation, {
+        startDate: '2025-01-01',
+      });
+    });
+  });
+});
+
+describe('sessionDetailsValidation', () => {
+  it('should pass with valid params', () => {
+    const result = validate(analyticsValidation.sessionDetailsValidation, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
+    assert.ok(result);
+  });
+
+  it('should pass with optional startIndex and count', () => {
+    const result = validate(analyticsValidation.sessionDetailsValidation, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      count: 10,
+      startIndex: 2,
+    });
+    assert.ok(result);
+  });
+
+  it('should fail without searchClientId', () => {
+    assert.throws(() => {
+      validate(analyticsValidation.sessionDetailsValidation, {
+        startDate: '2025-01-01',
+        endDate: '2025-01-31',
+      });
+    });
+  });
+});
+
+describe('similarValidationWithCountAndOffset', () => {
+  it('should pass with offset', () => {
+    const result = validate(analyticsValidation.similarValidationWithCountAndOffset, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      count: 10,
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      offset: 2,
+    });
+    assert.ok(result);
+  });
+
+  it('should pass without offset (backward compatible)', () => {
+    const result = validate(analyticsValidation.similarValidationWithCountAndOffset, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      count: 10,
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
+    assert.ok(result);
+  });
+
+  it('should fail with count over 500', () => {
+    assert.throws(() => {
+      validate(analyticsValidation.similarValidationWithCountAndOffset, {
+        startDate: '2025-01-01',
+        endDate: '2025-01-31',
+        count: 501,
+        searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      });
+    });
+  });
+});
+
+// --- Class instantiation ---
+
+describe('SearchClients class', () => {
+  it('should instantiate without errors', () => {
+    const mockAuth = { getAuthHeader: async () => 'test', authType: 'apiKey' };
+    const client = new SearchClients({ instance: 'https://test.searchunify.com', timeout: 5000 }, mockAuth);
+    assert.ok(client);
+  });
+
+  it('should have getSearchClients method', () => {
+    const mockAuth = { getAuthHeader: async () => 'test', authType: 'apiKey' };
+    const client = new SearchClients({ instance: 'https://test.searchunify.com', timeout: 5000 }, mockAuth);
+    assert.equal(typeof client.getSearchClients, 'function');
+  });
+});
+
+describe('SearchUnifyRestClient exposes SearchClients', () => {
+  it('should have SearchClients() accessor', () => {
+    const client = new SearchUnifyRestClient({
+      instance: 'https://test.searchunify.com',
+      authType: 'apiKey',
+      apiKey: 'test-key',
+    });
+    assert.ok(client.SearchClients);
+    assert.equal(typeof client.SearchClients, 'function');
+    const sc = client.SearchClients();
+    assert.equal(typeof sc.getSearchClients, 'function');
+  });
+});
+
+describe('Analytics class - new methods exist', () => {
+  const mockAuth = { getAuthHeader: async () => 'test', authType: 'apiKey' };
+  const analytics = new Analytics({ instance: 'https://test.searchunify.com', timeout: 5000 }, mockAuth);
+
+  it('should have getAverageClickPosition method', () => {
+    assert.equal(typeof analytics.getAverageClickPosition, 'function');
+  });
+
+  it('should have getSessionDetails method', () => {
+    assert.equal(typeof analytics.getSessionDetails, 'function');
+  });
+});
+
+describe('Content class - getSearchClients removed', () => {
+  const mockAuth = { getAuthHeader: async () => 'test', authType: 'apiKey' };
+  const content = new Content({ instance: 'https://test.searchunify.com', timeout: 5000 }, mockAuth);
+
+  it('should NOT have getSearchClients (moved to SearchClients class)', () => {
+    assert.equal(content.getSearchClients, undefined);
+  });
+});
+
+// --- Pagination backward compatibility ---
+
+describe('Existing methods accept offset param', () => {
+  it('getAllSearchQuery validates with offset', () => {
+    const result = validate(analyticsValidation.similarValidationWithCountAndOffset, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      count: 10,
+      offset: 3,
+    });
+    assert.ok(result);
+  });
+
+  it('getAllSearchQuery validates without offset (backward compat)', () => {
+    const result = validate(analyticsValidation.similarValidationWithCountAndOffset, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      count: 10,
+    });
+    assert.ok(result);
+  });
+});


### PR DESCRIPTION
…s and pagination

- Add SearchClients class with getSearchClients() method (GET /api/v1/search-clients)
- Add getAverageClickPosition() method (POST /api/v2/searchQuery/averageClickPosition)
- Add getSessionDetails() method (GET /api/v2/session/log/all)
- Add offset param to 5 existing analytics methods for pagination support
- Add validation schemas for new methods
- Expose SearchClients() accessor on SearchUnifyRestClient
- Add unit tests (21 tests)