### PR TITLE
Mcp api fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "su-sdk",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "SearchUnify javascript SDK enables developers to easily work with the SearchUnify platform and build scalable solutions with search, analytics, crawlers and more.",
     "main": "index.js",
     "repository": {

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -15,6 +15,30 @@ const buildSearchClassificationQueryParams = (params) => qs.stringify({
   sortType: params.sortType
 });
 
+/** Session list rows from API have either uid (sessions) or eco_id (eco_sessions); expose both keys for consumers. */
+const normalizeSessionListTableData = (data) => {
+  if (!data || typeof data !== 'object' || !Array.isArray(data.sessions)) {
+    return data;
+  }
+  return {
+    ...data,
+    sessions: data.sessions.map((row) => {
+      if (row == null || typeof row !== 'object') {
+        return row;
+      }
+      const hasUid = Object.prototype.hasOwnProperty.call(row, 'uid');
+      const hasEco = Object.prototype.hasOwnProperty.call(row, 'eco_id');
+      if (hasUid && !hasEco) {
+        return { ...row, eco_id: null };
+      }
+      if (hasEco && !hasUid) {
+        return { ...row, uid: null };
+      }
+      return row;
+    })
+  };
+};
+
 class Analytics extends Base {
   #instance;
 
@@ -523,7 +547,12 @@ class Analytics extends Base {
       timeout: this.#timeout,
       method: requestMethods.get,
       url: `${this.#instance}${ANALYTICS.SESSION_LIST_TABLE}?${queryParams}`
-    }, this.#authObj);
+    }, this.#authObj).then((result) => {
+      if (result && result.status && result.data) {
+        return { ...result, data: normalizeSessionListTableData(result.data) };
+      }
+      return result;
+    });
   }
 
   getTileDataContent(params) {

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -483,6 +483,7 @@ class Analytics extends Base {
       uid: params.searchClientId,
       count: params.count,
       sessionId: params.sessionId,
+      startIndex: params.startIndex,
     });
 
     return HttpRequest({

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -499,6 +499,32 @@ class Analytics extends Base {
       url: `${this.#instance}${ANALYTICS.SESSION_LOG}?${queryParams}`
     }, this.#authObj);
   }
+
+  getSessionListTable(params) {
+    validate(analytics.sessionListTableValidation, params);
+
+    const query = {
+      startDate: params.startDate,
+      endDate: params.endDate,
+      uid: params.searchClientId,
+      count: params.count,
+      sessionId: params.sessionId,
+      startIndex: params.startIndex,
+    };
+    if (params.sortByField !== undefined && params.sortByField !== null) {
+      query.sortByField = params.sortByField;
+    }
+    if (params.sortType !== undefined && params.sortType !== null) {
+      query.sortType = params.sortType;
+    }
+    const queryParams = qs.stringify(query);
+
+    return HttpRequest({
+      timeout: this.#timeout,
+      method: requestMethods.get,
+      url: `${this.#instance}${ANALYTICS.SESSION_LIST_TABLE}?${queryParams}`
+    }, this.#authObj);
+  }
 }
 
 module.exports = {

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -482,6 +482,7 @@ class Analytics extends Base {
       endDate: params.endDate,
       uid: params.searchClientId,
       count: params.count,
+      sessionId: params.sessionId,
     });
 
     return HttpRequest({

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -477,14 +477,21 @@ class Analytics extends Base {
   getSessionDetails(params) {
     validate(analytics.sessionDetailsValidation, params);
 
-    const queryParams = qs.stringify({
+    const query = {
       startDate: params.startDate,
       endDate: params.endDate,
       uid: params.searchClientId,
       count: params.count,
       sessionId: params.sessionId,
       startIndex: params.startIndex,
-    });
+    };
+    if (params.sortByField !== undefined && params.sortByField !== null) {
+      query.sortByField = params.sortByField;
+    }
+    if (params.sortType !== undefined && params.sortType !== null) {
+      query.sortType = params.sortType;
+    }
+    const queryParams = qs.stringify(query);
 
     return HttpRequest({
       timeout: this.#timeout,

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -5,6 +5,16 @@ const { analytics } = require('../validations');
 const { validate } = require('../validations/joi-validator');
 const { Base } = require('./base');
 
+const buildSearchClassificationQueryParams = (params) => qs.stringify({
+  startDate: params.startDate,
+  endDate: params.endDate,
+  count: params.count,
+  searchClientId: params.searchClientId,
+  pageNumber: params.pageNumber,
+  sortByField: params.sortByField,
+  sortType: params.sortType
+});
+
 class Analytics extends Base {
   #instance;
 
@@ -67,12 +77,7 @@ class Analytics extends Base {
   getAllSearchQuery(params) {
     validate(analytics.similarValidationWithCount, params);
 
-    const queryParams = qs.stringify({
-      startDate: params.startDate,
-      endDate: params.endDate,
-      count: params.count,
-      searchClientId: params.searchClientId,
-    });
+    const queryParams = buildSearchClassificationQueryParams(params);
 
     return HttpRequest({
       timeout: this.#timeout,
@@ -84,12 +89,7 @@ class Analytics extends Base {
   searchQueryWithResult(params) {
     validate(analytics.similarValidationWithCount, params);
 
-    const queryParams = qs.stringify({
-      startDate: params.startDate,
-      endDate: params.endDate,
-      count: params.count,
-      searchClientId: params.searchClientId,
-    });
+    const queryParams = buildSearchClassificationQueryParams(params);
 
     return HttpRequest({
       timeout: this.#timeout,
@@ -101,12 +101,7 @@ class Analytics extends Base {
   searchQueryWithNoClicks(params) {
     validate(analytics.similarValidationWithCount, params);
 
-    const queryParams = qs.stringify({
-      startDate: params.startDate,
-      endDate: params.endDate,
-      count: params.count,
-      searchClientId: params.searchClientId,
-    });
+    const queryParams = buildSearchClassificationQueryParams(params);
 
     return HttpRequest({
       timeout: this.#timeout,
@@ -118,12 +113,7 @@ class Analytics extends Base {
   searchQueryWithoutResults(params) {
     validate(analytics.similarValidationWithCount, params);
 
-    const queryParams = qs.stringify({
-      startDate: params.startDate,
-      endDate: params.endDate,
-      count: params.count,
-      searchClientId: params.searchClientId,
-    });
+    const queryParams = buildSearchClassificationQueryParams(params);
 
     return HttpRequest({
       timeout: this.#timeout,

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -481,13 +481,20 @@ class Analytics extends Base {
   }
 
   getAverageClickPosition(params) {
-    validate(analytics.averageClickPositionValidation, params);
+    validate(analytics.similarValidation, params);
 
     const payload = JSON.stringify({
-      startDate: params.startDate,
-      endDate: params.endDate,
-      searchClientId: params.searchClientId,
-      count: params.count,
+      from: params.startDate,
+      to: params.endDate,
+      uid: params.searchClientId,
+      ecoId: params.ecoSystemId,
+      tenantId: params.tenantId,
+      internalUser: params.internalUser,
+      userMetricsFilters: params.userMetricsFilters,
+      emailTracking: params.emailTracking,
+      userMetricsFlag: params.userMetricsFlag,
+      userMetricsLimit: params.userMetricsLimit,
+      userMetricsOffset: params.userMetricsOffset,
     });
 
     return HttpRequest({

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -525,6 +525,75 @@ class Analytics extends Base {
       url: `${this.#instance}${ANALYTICS.SESSION_LIST_TABLE}?${queryParams}`
     }, this.#authObj);
   }
+
+  getTileDataContent(params) {
+    validate(analytics.similarValidation, params);
+
+    const payload = JSON.stringify({
+      from: params.startDate,
+      to: params.endDate,
+      uid: params.searchClientId,
+      ecoId: params.ecoSystemId,
+      userMetricsFilters: params.userMetricsFilters,
+      emailTracking: params.emailTracking,
+      userMetricsFlag: params.userMetricsFlag,
+      userMetricsLimit: params.userMetricsLimit,
+      userMetricsOffset: params.userMetricsOffset
+    });
+
+    return HttpRequest({
+      timeout: this.#timeout,
+      method: requestMethods.post,
+      url: `${this.#instance}${ANALYTICS.TILE_DATA_CONTENT}`,
+      data: payload
+    }, this.#authObj);
+  }
+
+  getTileDataMetrics1(params) {
+    validate(analytics.similarValidation, params);
+
+    const payload = JSON.stringify({
+      from: params.startDate,
+      to: params.endDate,
+      uid: params.searchClientId,
+      ecoId: params.ecoSystemId,
+      userMetricsFilters: params.userMetricsFilters,
+      emailTracking: params.emailTracking,
+      userMetricsFlag: params.userMetricsFlag,
+      userMetricsLimit: params.userMetricsLimit,
+      userMetricsOffset: params.userMetricsOffset
+    });
+
+    return HttpRequest({
+      timeout: this.#timeout,
+      method: requestMethods.post,
+      url: `${this.#instance}${ANALYTICS.TILE_DATA_METRICS_1}`,
+      data: payload
+    }, this.#authObj);
+  }
+
+  getTileDataMetrics2(params) {
+    validate(analytics.similarValidation, params);
+
+    const payload = JSON.stringify({
+      from: params.startDate,
+      to: params.endDate,
+      uid: params.searchClientId,
+      ecoId: params.ecoSystemId,
+      userMetricsFilters: params.userMetricsFilters,
+      emailTracking: params.emailTracking,
+      userMetricsFlag: params.userMetricsFlag,
+      userMetricsLimit: params.userMetricsLimit,
+      userMetricsOffset: params.userMetricsOffset
+    });
+
+    return HttpRequest({
+      timeout: this.#timeout,
+      method: requestMethods.post,
+      url: `${this.#instance}${ANALYTICS.TILE_DATA_METRICS_2}`,
+      data: payload
+    }, this.#authObj);
+  }
 }
 
 module.exports = {

--- a/src/utils/su-apis.js
+++ b/src/utils/su-apis.js
@@ -21,7 +21,7 @@ exports.ANALYTICS = {
   ARTICLE_DEFLECTED_CASES: '/api/v2/conversion/articlesDeflectedCase',
   ATTACHED_ARTICLE: '/api/v2/conversion/attachedArticles',
   ATTACHED_ON_CASE: '/api/v2/conversion/attachedOnCase',
-  AVERAGE_CLICK_POSITION: '/api/v2/searchQuery/averageClickPosition',
+  AVERAGE_CLICK_POSITION: '/api/v2/overview/averageClickPositionChart',
   TILE_DATA_CONTENT: '/api/v2/content/tileDataContent',
   TILE_DATA_METRICS_1: '/api/v2/overview/tileDataMetrics1',
   TILE_DATA_METRICS_2: '/api/v2/overview/tileDataMetrics2',

--- a/src/utils/su-apis.js
+++ b/src/utils/su-apis.js
@@ -22,6 +22,9 @@ exports.ANALYTICS = {
   ATTACHED_ARTICLE: '/api/v2/conversion/attachedArticles',
   ATTACHED_ON_CASE: '/api/v2/conversion/attachedOnCase',
   AVERAGE_CLICK_POSITION: '/api/v2/searchQuery/averageClickPosition',
+  TILE_DATA_CONTENT: '/api/v2/content/tileDataContent',
+  TILE_DATA_METRICS_1: '/api/v2/overview/tileDataMetrics1',
+  TILE_DATA_METRICS_2: '/api/v2/overview/tileDataMetrics2',
   SESSION_LOG: '/api/v2/session/log/all',
   SESSION_LIST_TABLE: '/api/v2/session/list/table'
 };

--- a/src/utils/su-apis.js
+++ b/src/utils/su-apis.js
@@ -22,7 +22,8 @@ exports.ANALYTICS = {
   ATTACHED_ARTICLE: '/api/v2/conversion/attachedArticles',
   ATTACHED_ON_CASE: '/api/v2/conversion/attachedOnCase',
   AVERAGE_CLICK_POSITION: '/api/v2/searchQuery/averageClickPosition',
-  SESSION_LOG: '/api/v2/session/log/all'
+  SESSION_LOG: '/api/v2/session/log/all',
+  SESSION_LIST_TABLE: '/api/v2/session/list/table'
 };
 
 exports.AUTH_API = {

--- a/src/validations/analytics-validation.js
+++ b/src/validations/analytics-validation.js
@@ -128,6 +128,10 @@ const sessionDetailsValidation = Joi.object().keys({
   count: Joi.number().min(1).optional(),
   sessionId: Joi.string().trim().optional(),
   startIndex: Joi.number().min(1).optional(),
+  sortByField: Joi.string()
+    .valid('search', 'click', 'support', 'case', 'end_date', 'start_date')
+    .optional(),
+  sortType: Joi.string().valid('asc', 'desc').optional(),
 });
 
 const searchSessionBySSIdValidation = Joi.object().keys({

--- a/src/validations/analytics-validation.js
+++ b/src/validations/analytics-validation.js
@@ -125,7 +125,8 @@ const sessionDetailsValidation = Joi.object().keys({
   startDate: Joi.string().trim().required(),
   endDate: Joi.string().trim().required(),
   searchClientId: Joi.string().uuid().trim().required(),
-  count: Joi.number().min(1).max(500).optional(),
+  count: Joi.number().min(1).optional(),
+  sessionId: Joi.string().trim().optional(),
 });
 
 const searchSessionBySSIdValidation = Joi.object().keys({

--- a/src/validations/analytics-validation.js
+++ b/src/validations/analytics-validation.js
@@ -24,6 +24,15 @@ const similarValidation = Joi.object().keys({
   endDate: Joi.string().trim().required(),
   searchClientId: Joi.string().uuid().trim(),
   ecoSystemId: Joi.string().trim().optional(),
+  tenantId: Joi.string().uuid().trim().optional(),
+  internalUser: Joi.alternatives()
+    .try(
+      Joi.string().valid('all', 'internal', 'external', 'externalOnly'),
+      Joi.boolean()
+    )
+    .optional(),
+  /** Ignored by overview POST bodies; allowed for callers (e.g. MCP) that share the same schema. */
+  count: Joi.number().min(1).max(500).optional(),
   emailTracking: Joi.boolean().optional(),
   conversionType: Joi.string().optional(),
   ...userMetricsValidation
@@ -114,12 +123,8 @@ const attachedOnCaseValidation = Joi.object().keys({
   'object.nand': 'searchClientId and ecoSystemId cannot be used together',
 });
 
-const averageClickPositionValidation = Joi.object().keys({
-  startDate: Joi.string().trim().required(),
-  endDate: Joi.string().trim().required(),
-  searchClientId: Joi.string().uuid().trim().optional(),
-  count: Joi.number().min(1).max(500).optional(),
-});
+/** Same as overview POST validation (getAverageClickPosition uses similarValidation). Kept for backward compatibility. */
+const averageClickPositionValidation = similarValidation;
 
 const sessionDetailsValidation = Joi.object().keys({
   startDate: Joi.string().trim().required(),

--- a/src/validations/analytics-validation.js
+++ b/src/validations/analytics-validation.js
@@ -129,7 +129,20 @@ const sessionDetailsValidation = Joi.object().keys({
   sessionId: Joi.string().trim().optional(),
   startIndex: Joi.number().min(1).optional(),
   sortByField: Joi.string()
-    .valid('search', 'click', 'support', 'case', 'end_date', 'start_date')
+    .valid('search', 'click', 'support', 'case', 'page_view', 'end_date', 'start_date')
+    .optional(),
+  sortType: Joi.string().valid('asc', 'desc').optional(),
+});
+
+const sessionListTableValidation = Joi.object().keys({
+  startDate: Joi.string().trim().required(),
+  endDate: Joi.string().trim().required(),
+  searchClientId: Joi.string().uuid().trim().required(),
+  count: Joi.number().min(1).max(500).required(),
+  sessionId: Joi.string().trim().optional(),
+  startIndex: Joi.number().min(1).optional(),
+  sortByField: Joi.string()
+    .valid('search', 'click', 'support', 'case', 'page_view', 'end_date', 'start_date')
     .optional(),
   sortType: Joi.string().valid('asc', 'desc').optional(),
 });
@@ -155,5 +168,6 @@ module.exports = {
   attachedOnCaseValidation,
   searchSessionBySSIdValidation,
   averageClickPositionValidation,
-  sessionDetailsValidation
+  sessionDetailsValidation,
+  sessionListTableValidation
 };

--- a/src/validations/analytics-validation.js
+++ b/src/validations/analytics-validation.js
@@ -38,7 +38,9 @@ const similarValidationWithCount = Joi.object().keys({
   searchClientId: Joi.string().uuid().trim(),
   ecoSystemId: Joi.string().trim().optional(),
   ...userMetricsValidation,
-  pageNumber: Joi.number().optional(),
+  pageNumber: Joi.number().min(1).optional(),
+  sortByField: Joi.string().valid('count').optional(),
+  sortType: Joi.string().valid('asc', 'desc').optional(),
 }).nand('searchClientId', 'ecoSystemId').messages({
   'object.nand': 'searchClientId and ecoSystemId cannot be used together',
 });

--- a/src/validations/analytics-validation.js
+++ b/src/validations/analytics-validation.js
@@ -127,6 +127,7 @@ const sessionDetailsValidation = Joi.object().keys({
   searchClientId: Joi.string().uuid().trim().required(),
   count: Joi.number().min(1).optional(),
   sessionId: Joi.string().trim().optional(),
+  startIndex: Joi.number().min(1).optional(),
 });
 
 const searchSessionBySSIdValidation = Joi.object().keys({

--- a/test/test-new-apis.js
+++ b/test/test-new-apis.js
@@ -83,6 +83,17 @@ describe('sessionDetailsValidation', () => {
     assert.ok(result);
   });
 
+  it('should pass with optional sessionId filter', () => {
+    const result = validate(analyticsValidation.sessionDetailsValidation, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      count: 10,
+      sessionId: '1649742483444046',
+    });
+    assert.ok(result);
+  });
+
   it('should fail without searchClientId', () => {
     assert.throws(() => {
       validate(analyticsValidation.sessionDetailsValidation, {

--- a/test/test-new-apis.js
+++ b/test/test-new-apis.js
@@ -94,6 +94,18 @@ describe('sessionDetailsValidation', () => {
     assert.ok(result);
   });
 
+  it('should pass with optional sortByField and sortType', () => {
+    const result = validate(analyticsValidation.sessionDetailsValidation, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      count: 10,
+      sortByField: 'click',
+      sortType: 'desc',
+    });
+    assert.ok(result);
+  });
+
   it('should fail without searchClientId', () => {
     assert.throws(() => {
       validate(analyticsValidation.sessionDetailsValidation, {

--- a/test/test-new-apis.js
+++ b/test/test-new-apis.js
@@ -20,6 +20,10 @@ describe('su-apis URLs', () => {
     assert.equal(ANALYTICS.SESSION_LOG, '/api/v2/session/log/all');
   });
 
+  it('should have SESSION_LIST_TABLE url', () => {
+    assert.equal(ANALYTICS.SESSION_LIST_TABLE, '/api/v2/session/list/table');
+  });
+
   it('should have SEARCH_CLIENTS url', () => {
     assert.equal(CONTENT_API.SEARCH_CLIENTS, '/api/v2/search-clients');
   });
@@ -114,6 +118,52 @@ describe('sessionDetailsValidation', () => {
       });
     });
   });
+
+  it('should accept sortByField page_view', () => {
+    const result = validate(analyticsValidation.sessionDetailsValidation, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      count: 10,
+      sortByField: 'page_view',
+      sortType: 'desc',
+    });
+    assert.ok(result);
+  });
+});
+
+describe('sessionListTableValidation', () => {
+  it('should pass with required count and max 500', () => {
+    const result = validate(analyticsValidation.sessionListTableValidation, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      count: 500,
+    });
+    assert.ok(result);
+  });
+
+  it('should fail when count exceeds 500', () => {
+    assert.throws(() => {
+      validate(analyticsValidation.sessionListTableValidation, {
+        startDate: '2025-01-01',
+        endDate: '2025-01-31',
+        searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        count: 501,
+      });
+    });
+  });
+
+  it('should accept optional startIndex without upper bound', () => {
+    const result = validate(analyticsValidation.sessionListTableValidation, {
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      searchClientId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      count: 100,
+      startIndex: 500,
+    });
+    assert.ok(result);
+  });
 });
 
 
@@ -157,6 +207,10 @@ describe('Analytics class - new methods exist', () => {
 
   it('should have getSessionDetails method', () => {
     assert.equal(typeof analytics.getSessionDetails, 'function');
+  });
+
+  it('should have getSessionListTable method', () => {
+    assert.equal(typeof analytics.getSessionListTable, 'function');
   });
 });
 

--- a/test/test-new-apis.js
+++ b/test/test-new-apis.js
@@ -13,7 +13,7 @@ const { validate } = require('../src/validations/joi-validator');
 
 describe('su-apis URLs', () => {
   it('should have AVERAGE_CLICK_POSITION url', () => {
-    assert.equal(ANALYTICS.AVERAGE_CLICK_POSITION, '/api/v2/searchQuery/averageClickPosition');
+    assert.equal(ANALYTICS.AVERAGE_CLICK_POSITION, '/api/v2/overview/averageClickPositionChart');
   });
 
   it('should have SESSION_LOG url', () => {


### PR DESCRIPTION
### `su-sdk-js`

- **Endpoints:** Session list table; tile POSTs (`tileDataContent`, `tileDataMetrics1`, `tileDataMetrics2`); average click position → `/api/v2/overview/averageClickPositionChart`.
- **Search classification:** Query params include `pageNumber`, `sortByField`, `sortType`.
- **Session log & session list:** `sessionId`, `startIndex`, optional sort; session list rows normalize `uid` / `eco_id`.
- **Validation** aligned with the above; average click position uses the same overview-style payload pattern as related calls.
