### PR TITLE
fix(validation): require indexName for leadershipAssistedCaseVolume

### DIFF
--- a/src/validations/analytics-validation.js
+++ b/src/validations/analytics-validation.js
@@ -580,10 +580,10 @@ const leadershipSelfSolveVolume = Joi.object({
   return value;
 });
 
-/** POST /api/v2/leadership/assisted-case-volume — tenant-scoped rollup; uid/ecoId not required on this route. */
+/** POST /api/v2/leadership/assisted-case-volume — tenant-scoped rollup; uid/ecoId not required on this route. `indexName` is required. */
 const leadershipAssistedCaseVolume = Joi.object({
   tenantId: Joi.string().uuid().trim().optional(),
-  indexName: Joi.string().trim().optional().allow(null, ''),
+  indexName: Joi.string().trim().required(),
   internalUser: Joi.alternatives()
     .try(
       Joi.string().valid('all', 'internal', 'external', 'externalOnly'),


### PR DESCRIPTION
## Summary
- `leadershipAssistedCaseVolume`'s Joi schema (`src/validations/analytics-validation.js`) now requires `indexName` instead of allowing it to be omitted/null/empty.
- The backend's `/api/v2/leadership/assisted-case-volume` route can't correctly aggregate `case_volume` across content sources when `indexName` is omitted (its query LEFT JOINs only on quarter, not also on index_name, so multiple content sources produce duplicate rows per quarter instead of a real tenant-wide sum), and binding an `undefined` `indexName` into its raw SQL throws a Sequelize `Named bind parameter "$indexName" has no value` error.
- Companion changes: `su-mcp` now requires this field before calling the SDK at all, and the `analytics` backend route now validates it as mandatory too — this PR closes the last gap, since previously `su-sdk-js`'s own validation would silently let an omitted `indexName` through.

## Test plan
- [x] Verified directly against the SDK (bypassing su-mcp) that `Analytics.postLeadershipAssistedCaseVolume({ internalUser: "all" })` now throws `"indexName" is required`
- [x] Verified `Analytics.postLeadershipAssistedCaseVolume({ internalUser: "all", indexName: "..." })` still passes validation and the request proceeds normally